### PR TITLE
[discussion] Categorize Ansible tasks by eventual container

### DIFF
--- a/deploy/roles/dev/tasks/main.yml
+++ b/deploy/roles/dev/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# - unnecessary -
 - name: Install apt packages
   apt: name={{ item }} update_cache=yes
   with_items:
@@ -6,21 +7,26 @@
   - mongodb
   sudo: yes
 
+# - unnecessary-
 - name: Fix the permissions of the site destination folder
   file: path=/vagrant_data/_site state=directory owner=vagrant group=vagrant recurse=yes
 
+# container: build (as a mounted volume)
 - name: Install the dev Jekyll configuration
   copy: src=_config.yml dest=/vagrant_data/src/site_source/_config.yml
         owner=vagrant group=vagrant mode=0644
 
+# container: build (as a CMD)
 - name: Kick off an initial build
   shell: ./build_site.sh chdir=/vagrant_data
   sudo: yes
   sudo_user: vagrant
 
+# - unnecessary -
 - name: Install the watcher's init script
   template: src=watcher.conf.j2 dest=/etc/init/watcher.conf
   sudo: yes
 
+# - unnecessary -
 - name: Ensure that the watcher has started
   service: name=watcher state=started

--- a/deploy/roles/editors/tasks/main.yml
+++ b/deploy/roles/editors/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# host
 - name: Install vim and emacs
   apt: name={{ item }} state=latest update_cache=yes
   with_items:

--- a/deploy/roles/jekyll/tasks/main.yml
+++ b/deploy/roles/jekyll/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+# container: build
 - name: Install python-apt for apt_repository.
   apt: name={{ item }} state=latest
   with_items:
@@ -6,10 +7,13 @@
   - python-pycurl
   sudo: yes
 
+# container: build
+# probably obviated by base image
 - name: Add the Brightbox PPA
   apt_repository: repo=ppa:brightbox/ruby-ng state=present
   sudo: yes
 
+# container: build
 - name: Install system packages necessary for Jekyll
   apt: name={{ item }} state=latest update_cache=yes
   with_items:
@@ -18,6 +22,7 @@
   - openjdk-7-jre
   sudo: yes
 
+# container: build
 - name: Install pinned packages
   apt: name={{ item }} state=present
   with_items:
@@ -25,10 +30,13 @@
   - ruby2.1-dev=2.1.3-1bbox1~precise1
   sudo: yes
 
+# container: build
+# probably obviated by base image
 - name: Install bundler
   gem: name=bundler state=latest user_install=no
   sudo: yes
 
+# - unnecessary -
 - name: Get bundler information from GitHub if it's missing.
   get_url: url=https://raw.githubusercontent.com/rackerlabs/developer.rackspace.com/master/{{ item }}
            dest={{ sourceroot }}/{{ item }}
@@ -36,5 +44,6 @@
   - Gemfile
   - Gemfile.lock
 
+# container: build
 - name: Install Jekyll and its dependencies
   command: bundle install --gemfile={{ sourceroot }}/Gemfile

--- a/deploy/roles/sphinx/tasks/main.yml
+++ b/deploy/roles/sphinx/tasks/main.yml
@@ -1,9 +1,11 @@
 ---
+# container: build
 - name: Install system packages necessary for installing Sphinx
   apt: name={{ item }} state=latest update_cache=yes
   with_items:
   - gcc
   - python-setuptools
 
+# container: build
 - name: Install Sphinx
   easy_install: name=sphinx

--- a/deploy/roles/webserver/tasks/main.yml
+++ b/deploy/roles/webserver/tasks/main.yml
@@ -1,39 +1,50 @@
 ---
+# host
 - name: Disable password authentication for SSH
   copy: src=etc/ssh/sshd_config dest=/etc/ssh/sshd_config owner=root group=root mode=0644
   notify:
   - restart ssh server
 
+# host
 - name: Create user for pushing static site
   user: name=publisher comment="Site Publisher" state=present
         groups=www-data
 
+# host
 - name: Add SSH public key to authorized_keys for publisher user
   authorized_key: user=publisher key="{{ lookup('file', 'id_rsa.pub') }}"
                   state=present
 
+# host
 - name: Copy motd file
   copy: src=etc/motd dest=/etc/motd owner=root group=root mode=0644
 
+# host
 - name: Make {{ content_owner }} user owner of docroot directory
   file: path={{ docroot }} owner={{ content_owner }} recurse=yes state=directory
 
+# - unnecessary -
 - name: Make {{ content_owner }} user owner of the backend directory
   file: path={{ backendroot }} owner={{ content_owner }} recurse=yes state=directory
 
+# host
 - name: Install the configuration file
   template: src=drc-backend.config.json.j2 dest={{ backendroot }}/config.json
             owner={{ content_owner }} group={{ content_owner }} mode=0600
 
+# - unnecessary -
 - name: Prequisites for apt_repository tasks
   apt: name=python-apt state=installed
 
+# - unnecessary -
 - name: Node.js PPA
   apt_repository: repo='ppa:chris-lea/node.js' state=present update_cache=yes
 
+# container: devsite/
 - name: Recent node.js
   apt: name=nodejs state=installed
   sudo: yes
 
+# - unnecessary -
 - name: Forever.js
   npm: name=forever global=yes state=latest


### PR DESCRIPTION
:construction: This is a pull request for discussion, not intended to be merged :construction: 

In preparation for #974, we're going through the Ansible playbooks to categorize each task based on where we eventually want each job to live: the CoreOS host itself or one of the containers. I'm doing this by adding a comment to each.

- [x] dev_web.yml
- [ ] prod_web.yml
- [ ] staging_web.yml
- [ ] jenkins_push.yml