### PR TITLE
Clarifying pre-requisite

### DIFF
--- a/src/docs/cloud-files/getting-started/index.rst
+++ b/src/docs/cloud-files/getting-started/index.rst
@@ -109,6 +109,10 @@ To download objects directly into your local storage drive via SDK download:
 
 Get object via CDN URL
 ~~~~~~~~~~~~~~~~~~~~~~
+Pre-requisite: `CDN-enable the object's container`_.
+
+.. _CDN-enable the object's container: #cdn-enable-container
+
 To retrieve an object through a CDN URL, that, unlike a temporary URL, never expires and may be considered a publicly-accessible permalink:
 
 .. include:: samples/get_object_cdn.rst


### PR DESCRIPTION
This code snippet on getting the public URL of an object is much farther below the snippet where the container is CDN-enabled. I know at least one customer who tried this code snippet without the CDN-enabling code snippet first and failed as a result. 

This PR adds a single sentence that notes that CDN-enabling a container is a pre-requisite to getting the public URL of an object. It links to the code snippet on CDN-enabling a container.