### PR TITLE
Use variables initialized in previous code snippets.

### DIFF
--- a/src/docs/cloud-servers/getting-started/samples/create_server.rst
+++ b/src/docs/cloud-servers/getting-started/samples/create_server.rst
@@ -37,8 +37,8 @@
 
   $response = $server->create(array(
       'name'     => 'My new server',
-      'imageId'  => $imageId,
-      'flavorId' => $flavorId
+      'imageId'  => $image->getId(),
+      'flavorId' => $flavor->getId()
   ));
 
 .. code-block:: python

--- a/src/docs/cloud-servers/getting-started/samples/create_server_with_keypair.rst
+++ b/src/docs/cloud-servers/getting-started/samples/create_server_with_keypair.rst
@@ -40,8 +40,8 @@
 
   $response = $server->create(array(
       'name'     => 'My server',
-      'imageId'  => $imageId,
-      'flavorId' => $flavorId
+      'imageId'  => $image->getId(),
+      'flavorId' => $flavor->getId(),
       'keypair'  => 'my-keypair'
   ));
 


### PR DESCRIPTION
Currently, these code snippets use variables that are uninitialized. As a result readers are confused or their scripts cause errors.