### PR TITLE
Link to support page

### DIFF
--- a/src/site_source/_includes/sidebar-footer.html
+++ b/src/site_source/_includes/sidebar-footer.html
@@ -1,12 +1,7 @@
 <div class="callout">
   <span class="sidebarheader">Need Help?</span>
 
-  <p>
-    E-mail <a href="mailto:sdk-support@rackspace.com">sdk-support@rackspace.com</a>,<br>
-    tweet <a href="https://twitter.com/rackspace">@rackspace</a>,
-    chat with us in #rackspace on Freenode,
-    or post in <a href="https://community.rackspace.com/developers/default">our developer forum</a>.
-  </p>
+  <p><a href="/support">Developer-to-Developer Support</a></p>
 </div>
 
 <div class="callout">


### PR DESCRIPTION
Rather than have a paragraph of text in the left-hand nav we should keep it simple and just link to our support page. This is also consistent with the nav in the upper menu Help > Developer-to-Developer Support