### PR TITLE
turning curly bracket to parentheses

### DIFF
--- a/src/site_source/sdks/golang/index.html
+++ b/src/site_source/sdks/golang/index.html
@@ -41,10 +41,10 @@ import (
   "github.com/rackspace/gophercloud/rackspace/objectstorage/v1/accounts"
 )
 
-provider, err := rackspace.AuthenticatedClient{gophercloud.AuthOptions{
+provider, err := rackspace.AuthenticatedClient(gophercloud.AuthOptions{
   Username: "{username}",
   APIKey:   "{apiKey}",
-}}
+})
 
 service, err := rackspace.NewObjectStorageV1(provider, gophercloud.EndpointOpts{
   Region: "{region}",


### PR DESCRIPTION
Just caught a documentation bug...

In a golang example, the documentation uses a set of `{}` instead of `()` for `AuthenticatedClient`.  

The error thrown by the go compiler is:  `AuthenticatedClient` is not a type.  Simple fix.