### PR TITLE
Adding jclouds samples for the Rackspace CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ src/site_source/_config.yml
 
 # Currently active top-level Dockerfile
 /Dockerfile
+
+# Compiled Java classes
+
+**/*.class

--- a/full-examples/autoscale/AutoScale.java
+++ b/full-examples/autoscale/AutoScale.java
@@ -29,7 +29,6 @@ public class AutoScale {
     // about the cloud service API and specific instantiation values, such as the endpoint URL.
     private static final String PROVIDER = System.getProperty("provider.autoscale", "rackspace-autoscale-us");
 
-    // jclouds refers to "regions" as "zones"
     private static final String REGION = System.getProperty("region", "IAD");
 
     // Authentication credentials

--- a/full-examples/autoscale/AutoScale.java
+++ b/full-examples/autoscale/AutoScale.java
@@ -50,13 +50,13 @@ public class AutoScale {
     public static void main(String[] args) throws Exception {
         AutoscaleApi autoscaleApi = authenticate(USERNAME, API_KEY);
 
-        GroupApi groupApi = autoscaleApi.getGroupApiForZone(REGION);
+        GroupApi groupApi = autoscaleApi.getGroupApi(REGION);
         Group group = createScalingGroup(groupApi);
 
-        PolicyApi policyApi = autoscaleApi.getPolicyApiForZoneAndGroup(REGION, group.getId());
+        PolicyApi policyApi = autoscaleApi.getPolicyApi(REGION, group.getId());
         String policyId = getPolicyId(policyApi);
 
-        WebhookApi webhookApi = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy(REGION, group.getId(), policyId);
+        WebhookApi webhookApi = autoscaleApi.getWebhookApi(REGION, group.getId(), policyId);
         String webhookId = createWebhook(webhookApi, WEBHOOK_NAME);
         executeWebhook(webhookApi, webhookId);
 
@@ -126,17 +126,17 @@ public class AutoScale {
     }
 
     public static void deleteWebhook(AutoscaleApi autoscaleApi, Group group, String policyId, String webhookId) {
-        WebhookApi webhookApi = autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy(REGION, group.getId(), policyId);
+        WebhookApi webhookApi = autoscaleApi.getWebhookApi(REGION, group.getId(), policyId);
         webhookApi.delete(webhookId);
     }
 
     public static void deleteScalingPolicy(AutoscaleApi autoscaleApi, Group group, String policyId) {
-        PolicyApi policyApi = autoscaleApi.getPolicyApiForZoneAndGroup(REGION, group.getId());
+        PolicyApi policyApi = autoscaleApi.getPolicyApi(REGION, group.getId());
         policyApi.delete(policyId);
     }
 
     public static void deleteScalingGroup(AutoscaleApi autoscaleApi, Group group) {
-        GroupApi groupApi = autoscaleApi.getGroupApiForZone(REGION);
+        GroupApi groupApi = autoscaleApi.getGroupApi(REGION);
         groupApi.delete(group.getId());
     }
 

--- a/full-examples/cdn/CDN.java
+++ b/full-examples/cdn/CDN.java
@@ -1,0 +1,82 @@
+import java.net.URI;
+import java.util.ArrayList;
+
+import org.jclouds.ContextBuilder;
+import org.jclouds.openstack.poppy.v1.PoppyApi;
+import org.jclouds.openstack.poppy.v1.features.FlavorApi;
+import org.jclouds.openstack.poppy.v1.features.ServiceApi;
+import org.jclouds.openstack.poppy.v1.domain.CreateService;
+import org.jclouds.openstack.poppy.v1.domain.Flavor;
+import org.jclouds.openstack.poppy.v1.domain.Service;
+import org.jclouds.openstack.poppy.v1.domain.Origin;
+import org.jclouds.openstack.poppy.v1.domain.Domain;
+import org.jclouds.openstack.poppy.v1.domain.Caching;
+import org.jclouds.openstack.poppy.v1.domain.Restriction;
+
+import com.google.common.collect.ImmutableList;
+
+public class CDN {
+    // The jclouds Provider for the Rackspace CDN US service. It contains information
+    // about the service API and specific instantiation values, such as the endpoint URL.
+    public static final String PROVIDER = System.getProperty("provider", "rackspace-cdn-us");
+
+    // Authentication credentials
+    public static final String USERNAME = System.getProperty("username", "{username}");
+    public static final String API_KEY = System.getProperty("apikey", "{apiKey}");
+    public static final String FLAVOR_ID = "cdn";
+
+    public static void main(String[] args) throws Exception {
+        PoppyApi cdnApi = authenticate(USERNAME, API_KEY);
+
+        // List flavors
+        FlavorApi flavorApi = cdnApi.getFlavorApi();
+        ImmutableList<Flavor> flavors = flavorApi.list().toList();
+
+        // Get flavor
+        Flavor flavor = flavorApi.get(FLAVOR_ID);
+
+        // Create service
+        ServiceApi serviceApi = cdnApi.getServiceApi();
+        URI serviceURI = serviceApi.create(
+            CreateService.builder()
+                .name("jclouds_example_site")
+                .domains(
+                    ImmutableList.of(
+                        Domain.builder().domain("jclouds-example.com").build()))
+                .origins(
+                    ImmutableList.of(
+                        Origin.builder().origin("origin1.jclouds-example.com").build()))
+                .caching(new ArrayList<Caching>())
+                .restrictions(new ArrayList<Restriction>())
+                .flavorId(flavor.getId())
+                .build());
+
+        // List services
+        ImmutableList<Service> services = cdnApi.getServiceApi().list().concat().toList();
+
+        // Get service
+        Service service = serviceApi.get(services.get(0).getId());
+
+        // TODO: Replace this when we have an awaitDeployed predicate on Service.
+        Thread.sleep(15000);
+
+        // Update service
+        serviceURI = serviceApi.update(
+            service.getId(),
+            service,
+            service.toUpdatableService()
+                .name("updated service name")
+                .build());
+
+        // Delete service
+        serviceApi.delete(service.getId());
+    }
+
+    public static PoppyApi authenticate(String username, String apiKey) {
+        PoppyApi cdnApi = ContextBuilder.newBuilder(PROVIDER)
+            .credentials(username, apiKey)
+            .buildApi(PoppyApi.class);
+
+        return cdnApi;
+    }
+}

--- a/full-examples/cdn/CDN.java
+++ b/full-examples/cdn/CDN.java
@@ -31,27 +31,20 @@ public class CDN {
     public static void main(String[] args) throws Exception {
         PoppyApi cdnApi = authenticate(USERNAME, API_KEY);
 
-        // List flavors
         FlavorApi flavorApi = cdnApi.getFlavorApi();
         List<Flavor> flavors = listFlavors(flavorApi);
 
-        // Get flavor
         Flavor flavor = getFlavor(flavorApi, FLAVOR_ID);
 
-        // Create service
         ServiceApi serviceApi = cdnApi.getServiceApi();
         URI serviceURI = createService(serviceApi, flavor.getId());
 
-        // List services
         List<Service> services = listServices(serviceApi);
 
-        // Get service
         Service service = getService(serviceApi, services.get(0).getId());
 
-        // Update service
         serviceURI = updateService(serviceApi, service);
 
-        // Delete service
         deleteResources(cdnApi, service);
     }
 

--- a/full-examples/cdn/CDN.java
+++ b/full-examples/cdn/CDN.java
@@ -57,7 +57,8 @@ public class CDN {
         // Get service
         Service service = serviceApi.get(services.get(0).getId());
 
-        // TODO: Replace this when we have an awaitDeployed predicate on Service.
+        // TODO: Replace this when we have an awaitDeployed predicate on
+        // Service (see https://github.com/jclouds/jclouds-labs-openstack/pull/186).
         Thread.sleep(15000);
 
         // Update service

--- a/full-examples/cdn/CDN.java
+++ b/full-examples/cdn/CDN.java
@@ -1,7 +1,7 @@
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Collections;
 
 import org.jclouds.ContextBuilder;
 import org.jclouds.openstack.poppy.v1.PoppyApi;
@@ -81,8 +81,8 @@ public class CDN {
                 .origins(
                     ImmutableList.of(
                         Origin.builder().origin("origin1.jclouds-example.com").build()))
-                .caching(new ArrayList<Caching>())
-                .restrictions(new ArrayList<Restriction>())
+                .caching(Collections.<Caching>emptyList())
+                .restrictions(Collections.<Restriction>emptyList())
                 .flavorId(flavorId)
                 .build());
     }

--- a/full-examples/cdn/CDN.java
+++ b/full-examples/cdn/CDN.java
@@ -72,6 +72,8 @@ public class CDN {
     }
 
     public static URI createService(ServiceApi serviceApi, String flavorId) {
+        // TODO: Remove the .caching(...) and .restrictions(...) calls below
+        // when this bug is fixed: https://issues.apache.org/jira/browse/JCLOUDS-877
         return serviceApi.create(
             CreateService.builder()
                 .name("jclouds_example_site")

--- a/full-examples/cloud-block-storage/CloudBlockStorage.java
+++ b/full-examples/cloud-block-storage/CloudBlockStorage.java
@@ -37,12 +37,12 @@ public class CloudBlockStorage {
 
         CinderApi cinderApi = authenticate(USERNAME, API_KEY);
 
-        VolumeApi volumeApi = cinderApi.getVolumeApiForZone(REGION);
+        VolumeApi volumeApi = cinderApi.getVolumeApi(REGION);
         Volume volume = createVolume(volumeApi);
         Volume showVolume = showVolume(volumeApi, volume.getId());
         List<? extends Volume> volumes = listVolumes(volumeApi);
 
-        SnapshotApi snapshotApi = cinderApi.getSnapshotApiForZone(REGION);
+        SnapshotApi snapshotApi = cinderApi.getSnapshotApi(REGION);
         Snapshot snapshot = createSnapshot(snapshotApi, volume);
         Snapshot showSnapshot = showSnapshot(snapshotApi, snapshot.getId());
         List<? extends Snapshot> snapshots = listSnapshots(snapshotApi);
@@ -133,8 +133,8 @@ public class CloudBlockStorage {
 
     public static void deleteResources(CinderApi cinderApi, Snapshot snapshot, Volume volume)
           throws IOException, TimeoutException {
-       deleteSnapshot(cinderApi.getSnapshotApiForZone(REGION), snapshot);
-       deleteVolume(cinderApi.getVolumeApiForZone(REGION), volume);
+       deleteSnapshot(cinderApi.getSnapshotApi(REGION), snapshot);
+       deleteVolume(cinderApi.getVolumeApi(REGION), volume);
 
        Closeables.close(cinderApi, true);
    }

--- a/full-examples/cloud-block-storage/CloudBlockStorage.java
+++ b/full-examples/cloud-block-storage/CloudBlockStorage.java
@@ -23,7 +23,6 @@ public class CloudBlockStorage {
     // about the cloud service API and specific instantiation values, such as the endpoint URL.
     public static final String PROVIDER = System.getProperty("provider", "rackspace-cloudblockstorage-us");
 
-    // jclouds refers to "regions" as "zones"
     public static final String REGION = System.getProperty("region", "IAD");
 
     // Authentication credentials

--- a/full-examples/cloud-databases/CloudDatabases.java
+++ b/full-examples/cloud-databases/CloudDatabases.java
@@ -35,17 +35,17 @@ public class CloudDatabases {
 
         TroveApi troveApi = authenticate(USERNAME, API_KEY);
 
-        FlavorApi flavorApi = troveApi.getFlavorApiForZone(REGION);
+        FlavorApi flavorApi = troveApi.getFlavorApi(REGION);
         FluentIterable<Flavor> flavors = listFlavors(flavorApi);
         Flavor flavor = getFlavor(flavorApi);
 
-        InstanceApi instanceApi = troveApi.getInstanceApiForZone(REGION);
+        InstanceApi instanceApi = troveApi.getInstanceApi(REGION);
         Instance instance = createInstance(troveApi, instanceApi, flavor);
 
-        DatabaseApi databaseApi = troveApi.getDatabaseApiForZoneAndInstance(REGION, instance.getId());
+        DatabaseApi databaseApi = troveApi.getDatabaseApi(REGION, instance.getId());
         createDatabase(databaseApi, DATABASE_NAME);
 
-        UserApi userApi = troveApi.getUserApiForZoneAndInstance(REGION, instance.getId());
+        UserApi userApi = troveApi.getUserApi(REGION, instance.getId());
         createUser(userApi, DATABASE_USER_NAME, DATABASE_NAME);
 
         String rootPassword = enableRootUser(instanceApi, instance);

--- a/full-examples/cloud-databases/CloudDatabases.java
+++ b/full-examples/cloud-databases/CloudDatabases.java
@@ -21,7 +21,6 @@ public class CloudDatabases {
     // The jclouds Provider for the Rackspace Cloud Databases US cloud service. It contains information
     // about the cloud service API and specific instantiation values, such as the endpoint URL.
     public static final String PROVIDER = System.getProperty("provider", "rackspace-clouddatabases-us");
-    // jclouds refers to "regions" as "zones"
     public static final String REGION = System.getProperty("region", "IAD");
     // Authentication credentials
     public static final String USERNAME = System.getProperty("username", "{username}");

--- a/full-examples/cloud-dns/CloudDNS.java
+++ b/full-examples/cloud-dns/CloudDNS.java
@@ -38,7 +38,7 @@ public class CloudDNS {
         Domain domain = getZone(domainApi, domains);
         modifyZone(cloudDNSApi, domainApi, domain);
 
-        RecordApi recordApi = cloudDNSApi.getRecordApiForDomain(domain.getId());
+        RecordApi recordApi = cloudDNSApi.getRecordApi(domain.getId());
         Set<RecordDetail> records = createRecord(cloudDNSApi, recordApi);
         RecordDetail record = getRecord(recordApi, records);
         modifyRecord(cloudDNSApi, recordApi, record);
@@ -120,7 +120,7 @@ public class CloudDNS {
     public static void deleteRecord(CloudDNSApi cloudDNSApi, Domain domain, RecordDetail record)
             throws TimeoutException {
         List<String> recordIds = ImmutableList.of(record.getId());
-        RecordApi recordApi = cloudDNSApi.getRecordApiForDomain(domain.getId());
+        RecordApi recordApi = cloudDNSApi.getRecordApi(domain.getId());
 
         awaitComplete(cloudDNSApi, recordApi.delete(recordIds));
     }

--- a/full-examples/cloud-files/CloudFiles.java
+++ b/full-examples/cloud-files/CloudFiles.java
@@ -3,6 +3,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.io.BufferedOutputStream;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;

--- a/full-examples/cloud-files/CloudFiles.java
+++ b/full-examples/cloud-files/CloudFiles.java
@@ -32,7 +32,6 @@ public class CloudFiles {
     // about the cloud service API and specific instantiation values, such as the endpoint URL.
     public static final String PROVIDER = System.getProperty("provider", "rackspace-cloudfiles-us");
 
-    // jclouds refers to "regions" as "zones"
     public static final String REGION = System.getProperty("region", "IAD");
 
     // Authentication credentials

--- a/full-examples/cloud-files/CloudFiles.java
+++ b/full-examples/cloud-files/CloudFiles.java
@@ -48,22 +48,22 @@ public class CloudFiles {
         ContextBuilder builder = ContextBuilder.newBuilder(PROVIDER)
             .credentials(USERNAME, API_KEY);
 
-        BlobStore blobStore = builder.buildView(RegionScopedBlobStoreContext.class).blobStoreInRegion(REGION);
-        BlobRequestSigner signer = builder.buildView(RegionScopedBlobStoreContext.class).signerInRegion(REGION);
+        BlobStore blobStore = builder.buildView(RegionScopedBlobStoreContext.class).getBlobStore(REGION);
+        BlobRequestSigner signer = builder.buildView(RegionScopedBlobStoreContext.class).getSigner(REGION);
         CloudFilesApi cloudFilesApi = blobStore.getContext().unwrapApi(CloudFilesApi.class);
 
-        ContainerApi containerApi = cloudFilesApi.getContainerApiForRegion(REGION);
+        ContainerApi containerApi = cloudFilesApi.getContainerApi(REGION);
         createContainer(containerApi);
 
-        ObjectApi objectApi = cloudFilesApi.getObjectApiForRegionAndContainer(REGION, CONTAINER_NAME);
+        ObjectApi objectApi = cloudFilesApi.getObjectApi(REGION, CONTAINER_NAME);
         uploadObject(objectApi);
         SwiftObject object1 = getObjectSDK(objectApi);
         updateObjectMetadata(objectApi);
 
-        AccountApi accountApi = cloudFilesApi.getAccountApiForRegion(REGION);
+        AccountApi accountApi = cloudFilesApi.getAccountApi(REGION);
         URI tempURL = getObjectTempUrl(accountApi, signer);
 
-        CDNApi cdnApi = cloudFilesApi.getCDNApiForRegion(REGION);
+        CDNApi cdnApi = cloudFilesApi.getCDNApi(REGION);
         URI uri = enableCDN(cdnApi);
         getObjectCDN(cdnApi);
         disableCDN(cdnApi);

--- a/full-examples/cloud-files/CloudFiles.java
+++ b/full-examples/cloud-files/CloudFiles.java
@@ -90,7 +90,7 @@ public class CloudFiles {
     }
 
     public static SwiftObject getObjectSDK(ObjectApi objectApi) throws IOException {
-        SwiftObject object = objectApi.get(OBJECT_NAME);
+        SwiftObject object = objectApi.get("String" + OBJECT_NAME);
 
         // Write the object to a file
         InputStream inputStream = object.getPayload().openStream();

--- a/full-examples/cloud-load-balancers/CloudLoadBalancers.java
+++ b/full-examples/cloud-load-balancers/CloudLoadBalancers.java
@@ -56,24 +56,24 @@ public class CloudLoadBalancers {
         NodeApi nodeApi = clbApi.getNodeApi(REGION, loadBalancer.getId());
         createNodes(nodeApi);
 
-        waitForLoadBalancerToBecomeActive(lbApi, loadBalancer);
+        awaitActive(lbApi, loadBalancer);
         HealthMonitorApi healthMonitorApi = clbApi.getHealthMonitorApi(REGION, loadBalancer.getId());
         createHealthMonitor(healthMonitorApi);
         HealthMonitor healthMonitor = getHealthMonitor(healthMonitorApi);
 
-        waitForLoadBalancerToBecomeActive(lbApi, loadBalancer);
+        awaitActive(lbApi, loadBalancer);
         ConnectionApi connectionApi = clbApi.getConnectionApi(REGION, loadBalancer.getId());
         setThrottling(connectionApi);
         
-        waitForLoadBalancerToBecomeActive(lbApi, loadBalancer);
+        awaitActive(lbApi, loadBalancer);
         AccessRuleApi accessRuleApi = clbApi.getAccessRuleApi(REGION, loadBalancer.getId());
         blacklistIPs(accessRuleApi);
 
-        waitForLoadBalancerToBecomeActive(lbApi, loadBalancer);
+        awaitActive(lbApi, loadBalancer);
         ContentCachingApi contentCachingApi = clbApi.getContentCachingApi(REGION, loadBalancer.getId());
         enableContentCaching(contentCachingApi);
 
-        waitForLoadBalancerToBecomeActive(lbApi, loadBalancer);
+        awaitActive(lbApi, loadBalancer);
         ErrorPageApi errorPageApi = clbApi.getErrorPageApi(REGION, loadBalancer.getId());
         setCustomErrorPage(errorPageApi);
 
@@ -215,16 +215,16 @@ public class CloudLoadBalancers {
 
     public static void deleteResources(CloudLoadBalancersApi clbApi, LoadBalancerApi lbApi, LoadBalancer loadBalancer)
           throws IOException, TimeoutException {
-        waitForLoadBalancerToBecomeActive(lbApi, loadBalancer);
+        awaitActive(lbApi, loadBalancer);
         deleteNodes(clbApi, loadBalancer);
 
-        waitForLoadBalancerToBecomeActive(lbApi, loadBalancer);
+        awaitActive(lbApi, loadBalancer);
         deleteLoadBalancer(clbApi, loadBalancer);
 
         Closeables.close(clbApi, true);
     }
 
-    public static void waitForLoadBalancerToBecomeActive(LoadBalancerApi lbApi, LoadBalancer loadBalancer)
+    public static void awaitActive(LoadBalancerApi lbApi, LoadBalancer loadBalancer)
         throws TimeoutException {
         if (!LoadBalancerPredicates.awaitAvailable(lbApi).apply(loadBalancer)) {
             throw new TimeoutException("Timeout on loadBalancer: " + loadBalancer);

--- a/full-examples/cloud-load-balancers/CloudLoadBalancers.java
+++ b/full-examples/cloud-load-balancers/CloudLoadBalancers.java
@@ -214,7 +214,7 @@ public class CloudLoadBalancers {
     }
 
     public static void deleteResources(CloudLoadBalancersApi clbApi, LoadBalancerApi lbApi, LoadBalancer loadBalancer)
-          throws IOException, TimeoutException, InterruptedException {
+          throws IOException, TimeoutException {
         waitForLoadBalancerToBecomeActive(lbApi, loadBalancer);
         deleteNodes(clbApi, loadBalancer);
 

--- a/full-examples/cloud-load-balancers/CloudLoadBalancers.java
+++ b/full-examples/cloud-load-balancers/CloudLoadBalancers.java
@@ -39,7 +39,6 @@ public class CloudLoadBalancers {
     // about the cloud service API and specific instantiation values, such as the endpoint URL.
     public static final String PROVIDER = System.getProperty("provider", "rackspace-cloudloadbalancers-us");
 
-    // jclouds refers to "regions" as "zones"
     public static final String REGION = System.getProperty("region", "IAD");
 
     // Authentication credentials

--- a/full-examples/cloud-load-balancers/CloudLoadBalancers.java
+++ b/full-examples/cloud-load-balancers/CloudLoadBalancers.java
@@ -50,26 +50,26 @@ public class CloudLoadBalancers {
 
         CloudLoadBalancersApi clbApi = authenticate(USERNAME, API_KEY);
 
-        LoadBalancerApi lbApi = clbApi.getLoadBalancerApiForZone(REGION);
+        LoadBalancerApi lbApi = clbApi.getLoadBalancerApi(REGION);
         LoadBalancer loadBalancer = createLoadBalancer(lbApi);
 
-        NodeApi nodeApi = clbApi.getNodeApiForZoneAndLoadBalancer(REGION, loadBalancer.getId());
+        NodeApi nodeApi = clbApi.getNodeApi(REGION, loadBalancer.getId());
         createNodes(nodeApi);
 
-        HealthMonitorApi healthMonitorApi = clbApi.getHealthMonitorApiForZoneAndLoadBalancer(REGION, loadBalancer.getId());
+        HealthMonitorApi healthMonitorApi = clbApi.getHealthMonitorApi(REGION, loadBalancer.getId());
         createHealthMonitor(healthMonitorApi);
         HealthMonitor healthMonitor = getHealthMonitor(healthMonitorApi);
 
-        ConnectionApi connectionApi = clbApi.getConnectionApiForZoneAndLoadBalancer(REGION, loadBalancer.getId());
+        ConnectionApi connectionApi = clbApi.getConnectionApi(REGION, loadBalancer.getId());
         setThrottling(connectionApi);
         
-        AccessRuleApi accessRuleApi = clbApi.getAccessRuleApiForZoneAndLoadBalancer(REGION, loadBalancer.getId());
+        AccessRuleApi accessRuleApi = clbApi.getAccessRuleApi(REGION, loadBalancer.getId());
         blacklistIPs(accessRuleApi);
 
-        ContentCachingApi contentCachingApi = clbApi.getContentCachingApiForZoneAndLoadBalancer(REGION, loadBalancer.getId());
+        ContentCachingApi contentCachingApi = clbApi.getContentCachingApi(REGION, loadBalancer.getId());
         enableContentCaching(contentCachingApi);
 
-        ErrorPageApi errorPageApi = clbApi.getErrorPageApiForZoneAndLoadBalancer(REGION, loadBalancer.getId());
+        ErrorPageApi errorPageApi = clbApi.getErrorPageApi(REGION, loadBalancer.getId());
         setCustomErrorPage(errorPageApi);
 
         deleteResources(clbApi, loadBalancer);
@@ -106,7 +106,7 @@ public class CloudLoadBalancers {
         NovaApi novaApi = ContextBuilder.newBuilder("rackspace-cloudservers-us")
                 .credentials(USERNAME, API_KEY)
                 .buildApi(NovaApi.class);
-        ServerApi serverApi = novaApi.getServerApiForZone(REGION);
+        ServerApi serverApi = novaApi.getServerApi(REGION);
 
         Server server1 = serverApi.get("{serverId}");
         Server server2 = serverApi.get("{serverId}");
@@ -184,7 +184,7 @@ public class CloudLoadBalancers {
     }
 
     public static void deleteNodes(CloudLoadBalancersApi clbApi, LoadBalancer loadBalancer) {
-        NodeApi nodeApi = clbApi.getNodeApiForZoneAndLoadBalancer(REGION, loadBalancer.getId());
+        NodeApi nodeApi = clbApi.getNodeApi(REGION, loadBalancer.getId());
 
         Set<Node> nodes = nodeApi.list().concat().toSet();
 
@@ -193,7 +193,7 @@ public class CloudLoadBalancers {
     }
 
     public static void deleteLoadBalancer(CloudLoadBalancersApi clbApi, LoadBalancer loadBalancer) throws TimeoutException {
-        LoadBalancerApi lbApi = clbApi.getLoadBalancerApiForZone(REGION);
+        LoadBalancerApi lbApi = clbApi.getLoadBalancerApi(REGION);
         lbApi.delete(loadBalancer.getId());
         
         // Wait for the Load Balancer to be deleted

--- a/full-examples/cloud-queues/CloudQueues.java
+++ b/full-examples/cloud-queues/CloudQueues.java
@@ -34,14 +34,14 @@ public class CloudQueues {
         
         MarconiApi marconiApi = authenticate(USERNAME, API_KEY);
 
-        QueueApi queueApi = marconiApi.getQueueApiForZoneAndClient(REGION, CLIENT_ID);
+        QueueApi queueApi = marconiApi.getQueueApi(REGION, CLIENT_ID);
         createQueue(queueApi);
         listQueues(queueApi);
 
-        MessageApi messageApi = marconiApi.getMessageApiForZoneAndClientAndQueue(REGION, CLIENT_ID, QUEUE_NAME);
+        MessageApi messageApi = marconiApi.getMessageApi(REGION, CLIENT_ID, QUEUE_NAME);
         postMessage(messageApi);
 
-        ClaimApi claimApi = marconiApi.getClaimApiForZoneAndClientAndQueue(REGION, CLIENT_ID, QUEUE_NAME);
+        ClaimApi claimApi = marconiApi.getClaimApi(REGION, CLIENT_ID, QUEUE_NAME);
         List<Message> messages = claimMessage(claimApi);
         releaseMessage(claimApi, messages);
 
@@ -89,14 +89,14 @@ public class CloudQueues {
     }
 
     public static void deleteMessage(MarconiApi marconiApi, String messageId) {
-        MessageApi messageApi = marconiApi.getMessageApiForZoneAndClientAndQueue(REGION, CLIENT_ID, QUEUE_NAME);
+        MessageApi messageApi = marconiApi.getMessageApi(REGION, CLIENT_ID, QUEUE_NAME);
         List<String> messageIds = ImmutableList.of(messageId);
 
         messageApi.delete(messageIds);
     }
 
     public static void deleteQueue(MarconiApi marconiApi) {
-        QueueApi queueApi = marconiApi.getQueueApiForZoneAndClient(REGION, CLIENT_ID);
+        QueueApi queueApi = marconiApi.getQueueApi(REGION, CLIENT_ID);
         queueApi.delete(QUEUE_NAME);
     }
 

--- a/full-examples/cloud-queues/CloudQueues.java
+++ b/full-examples/cloud-queues/CloudQueues.java
@@ -20,7 +20,6 @@ public class CloudQueues {
     // about the cloud service API and specific instantiation values, such as the endpoint URL.
     public static final String PROVIDER = System.getProperty("provider", "rackspace-cloudqueues-us");
 
-    // jclouds refers to "regions" as "zones"
     public static final String REGION = System.getProperty("region", "IAD");
 
     // Authentication credentials

--- a/full-examples/cloud-servers/CloudServers.java
+++ b/full-examples/cloud-servers/CloudServers.java
@@ -30,7 +30,6 @@ public class CloudServers {
     // about the cloud service API and specific instantiation values, such as the endpoint URL.
     public static final String PROVIDER = System.getProperty("provider", "rackspace-cloudservers-us");
 
-    // jclouds refers to "regions" as "zones"
     public static final String REGION = System.getProperty("region", "IAD");
 
     // Authentication credentials

--- a/full-examples/cloud-servers/CloudServers.java
+++ b/full-examples/cloud-servers/CloudServers.java
@@ -42,18 +42,18 @@ public class CloudServers {
     public static void main(String[] args) throws Exception {
         NovaApi novaApi = authenticate(USERNAME, API_KEY);
 
-        ImageApi imageApi = novaApi.getImageApiForZone(REGION);
+        ImageApi imageApi = novaApi.getImageApi(REGION);
         List<? extends Image> images = listImages(imageApi);
         Image image = getImage(imageApi, images);
 
-        FlavorApi flavorApi = novaApi.getFlavorApiForZone(REGION);
+        FlavorApi flavorApi = novaApi.getFlavorApi(REGION);
         List<? extends Flavor> flavors = listFlavors(flavorApi);
         Flavor flavor = getFlavor(flavorApi, FLAVOR_ID);
 
-        KeyPairApi keyPairApi = novaApi.getKeyPairExtensionForZone(REGION).get();
+        KeyPairApi keyPairApi = novaApi.getKeyPairApi(REGION).get();
         KeyPair keyPair = createNewKeyPair(keyPairApi);
 
-        ServerApi serverApi = novaApi.getServerApiForZone(REGION);
+        ServerApi serverApi = novaApi.getServerApi(REGION);
         ServerCreated serverCreated = createServerWithKeypair(serverApi, image, flavor, keyPair);
         Server server = queryServerBuild(serverApi, serverCreated);
 
@@ -72,7 +72,7 @@ public class CloudServers {
         File keyPairFile = new File("{/home/my-user/.ssh/id_rsa.pub}");
         String publicKey = Files.toString(keyPairFile, UTF_8);
 
-        KeyPairApi keyPairApi = novaApi.getKeyPairExtensionForZone(REGION).get();
+        KeyPairApi keyPairApi = novaApi.getKeyPairApi(REGION).get();
         KeyPair keyPair = keyPairApi.createWithPublicKey("my-keypair", publicKey);
     }
 
@@ -133,12 +133,12 @@ public class CloudServers {
     }
 
     public static void deleteServer(NovaApi novaApi, Server server) {
-        ServerApi serverApi = novaApi.getServerApiForZone(REGION);
+        ServerApi serverApi = novaApi.getServerApi(REGION);
         serverApi.delete(server.getId());
     }
 
     public static void deleteKeyPair(NovaApi novaApi, KeyPair keyPair) {
-        KeyPairApi keyPairApi = novaApi.getKeyPairExtensionForZone(REGION).get();
+        KeyPairApi keyPairApi = novaApi.getKeyPairApi(REGION).get();
         keyPairApi.delete(keyPair.getName());
     }
 

--- a/full-examples/cloud-servers/CloudServers.java
+++ b/full-examples/cloud-servers/CloudServers.java
@@ -85,7 +85,7 @@ public class CloudServers {
     public static Image getImage(ImageApi imageApi, List<? extends Image> images) {
         Image ubuntu1404Image = Iterables.find(images, new Predicate<Image>() {
             public boolean apply(Image image) {
-                return image.getName().equals("Ubuntu 14.04 LTS (Trusty Tahr)");
+                return image.getName().startsWith("Ubuntu 14.04 LTS (Trusty Tahr)");
             }
         });
         Image image = imageApi.get(ubuntu1404Image.getId());

--- a/src/docs/CONTRIBUTING.rst
+++ b/src/docs/CONTRIBUTING.rst
@@ -129,7 +129,7 @@ Language Specific Code Conventions
 * Comment all references to regions and zones with::
 
     // jclouds refers to "regions" as "zones"  
-    VolumeApi volumeApi = cinderApi.getVolumeApiForZone(REGION);
+    VolumeApi volumeApi = cinderApi.getVolumeApi(REGION);
 
   
 * Pass the appropriate API to all static methods::

--- a/src/docs/auto-scale/getting-started/samples/create_scaling_group.rst
+++ b/src/docs/auto-scale/getting-started/samples/create_scaling_group.rst
@@ -38,7 +38,7 @@
   private static final String PUBLIC_NET = "00000000-0000-0000-0000-000000000000";
   private static final String SERVICE_NET = "11111111-1111-1111-1111-111111111111";
 
-  GroupApi groupApi = autoscaleApi.getGroupApiForZone("{region}");
+  GroupApi groupApi = autoscaleApi.getGroupApi("{region}");
 
   GroupConfiguration groupConfig = GroupConfiguration.builder()
           .maxEntities(5)

--- a/src/docs/auto-scale/getting-started/samples/create_scaling_policy.rst
+++ b/src/docs/auto-scale/getting-started/samples/create_scaling_policy.rst
@@ -17,7 +17,7 @@
 
 .. code-block:: java
 
-  PolicyApi policyApi = autoscaleApi.getPolicyApiForZoneAndGroup("{region}", "{scalingGroupId}");
+  PolicyApi policyApi = autoscaleApi.getPolicyApi("{region}", "{scalingGroupId}");
 
   CreateScalingPolicy scalingPolicy = CreateScalingPolicy.builder()
             .cooldown(360)

--- a/src/docs/auto-scale/getting-started/samples/create_scaling_webhook.rst
+++ b/src/docs/auto-scale/getting-started/samples/create_scaling_webhook.rst
@@ -15,7 +15,7 @@
 .. code-block:: java
 
   WebhookApi webhookApi =
-      autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("{region}", "{groupId}", "{policyId}");
+      autoscaleApi.getWebhookApi("{region}", "{groupId}", "{policyId}");
 
   FluentIterable<Webhook> result = webhookApi.create("{name}", ImmutableMap.<String, Object>of());
 

--- a/src/docs/auto-scale/getting-started/samples/delete_scaling_group.rst
+++ b/src/docs/auto-scale/getting-started/samples/delete_scaling_group.rst
@@ -8,7 +8,7 @@
 
 .. code-block:: java
 
-  GroupApi groupApi = autoscaleApi.getGroupApiForZone("{region}");
+  GroupApi groupApi = autoscaleApi.getGroupApi("{region}");
 
   groupApi.delete("{groupId}");
 

--- a/src/docs/auto-scale/getting-started/samples/delete_scaling_policy.rst
+++ b/src/docs/auto-scale/getting-started/samples/delete_scaling_policy.rst
@@ -8,7 +8,7 @@
 
 .. code-block:: java
 
-  PolicyApi policyApi = autoscaleApi.getPolicyApiForZoneAndGroup("{region}", "{scalingGroupId}");
+  PolicyApi policyApi = autoscaleApi.getPolicyApi("{region}", "{scalingGroupId}");
 
   policyApi.delete("{policyId}");
 

--- a/src/docs/auto-scale/getting-started/samples/delete_scaling_webhook.rst
+++ b/src/docs/auto-scale/getting-started/samples/delete_scaling_webhook.rst
@@ -13,7 +13,7 @@
 .. code-block:: java
 
   WebhookApi webhookApi =
-      autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("{region}", "{groupId}", "{policyId}");
+      autoscaleApi.getWebhookApi("{region}", "{groupId}", "{policyId}");
 
   webhookApi.delete("{webhookId}");
 

--- a/src/docs/auto-scale/getting-started/samples/execute_scaling_policy.rst
+++ b/src/docs/auto-scale/getting-started/samples/execute_scaling_policy.rst
@@ -9,7 +9,7 @@
 .. code-block:: java
 
   WebhhookApi webhookApi =
-      autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("{region}", "{groupId}", "{policyId}");
+      autoscaleApi.getWebhookApi("{region}", "{groupId}", "{policyId}");
 
   Webhook webhook = webhookApi.get("{webhookId}");
   AutoscaleUtils.execute(webhook.getAnonymousExecutionURI().get());

--- a/src/docs/auto-scale/getting-started/samples/get_scaling_group_details.rst
+++ b/src/docs/auto-scale/getting-started/samples/get_scaling_group_details.rst
@@ -9,7 +9,7 @@
 
 .. code-block:: java
 
-  GroupApi groupApi = autoscaleApi.getGroupApiForZone("{region}");
+  GroupApi groupApi = autoscaleApi.getGroupApi("{region}");
 
   Group group = groupApi.get("{groupId}");
 

--- a/src/docs/auto-scale/getting-started/samples/get_scaling_group_state.rst
+++ b/src/docs/auto-scale/getting-started/samples/get_scaling_group_state.rst
@@ -9,7 +9,7 @@
 
 .. code-block:: java
 
-  GroupApi groupApi = autoscaleApi.getGroupApiForZone("{region}");
+  GroupApi groupApi = autoscaleApi.getGroupApi("{region}");
 
   GroupState groupState = groupApi.getState("{scalingGroupId}");
 

--- a/src/docs/auto-scale/getting-started/samples/get_scaling_policy_details.rst
+++ b/src/docs/auto-scale/getting-started/samples/get_scaling_policy_details.rst
@@ -9,7 +9,7 @@
 
 .. code-block:: java
 
-  PolicyApi policyApi = autoscaleApi.getPolicyApiForZoneAndGroup("{region}", "{scalingGroupId}");
+  PolicyApi policyApi = autoscaleApi.getPolicyApi("{region}", "{scalingGroupId}");
 
   Policy policy = policyApi.get("{policyId}");
 

--- a/src/docs/auto-scale/getting-started/samples/get_scaling_webhook_details.rst
+++ b/src/docs/auto-scale/getting-started/samples/get_scaling_webhook_details.rst
@@ -14,7 +14,7 @@
 .. code-block:: java
 
   WebhookApi webhookApi =
-      autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("{region}", "{groupId}", "{policyId}");
+      autoscaleApi.getWebhookApi("{region}", "{groupId}", "{policyId}");
 
   Webhook webhook = webhookApi.get("{webhookId}");
 

--- a/src/docs/auto-scale/getting-started/samples/list_scaling_groups.rst
+++ b/src/docs/auto-scale/getting-started/samples/list_scaling_groups.rst
@@ -12,7 +12,7 @@
 
 .. code-block:: java
 
-  GroupApi groupApi = autoscaleApi.getGroupApiForZone("{region}");
+  GroupApi groupApi = autoscaleApi.getGroupApi("{region}");
 
   FluentIterable<Group> groups = groupApi.list();
 

--- a/src/docs/auto-scale/getting-started/samples/list_scaling_policies.rst
+++ b/src/docs/auto-scale/getting-started/samples/list_scaling_policies.rst
@@ -9,7 +9,7 @@
 
 .. code-block:: java
 
-  PolicyApi policyApi = autoscaleApi.getPolicyApiForZoneAndGroup("{region}", "{scalingGroupId}");
+  PolicyApi policyApi = autoscaleApi.getPolicyApi("{region}", "{scalingGroupId}");
 
   FluentIterable<Policy> policies = policyApi.list();
 

--- a/src/docs/auto-scale/getting-started/samples/list_scaling_webhooks.rst
+++ b/src/docs/auto-scale/getting-started/samples/list_scaling_webhooks.rst
@@ -15,7 +15,7 @@
 .. code-block:: java
 
   WebhookApi webhookApi =
-      autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("{region}", "{groupId}", "{policyId}");
+      autoscaleApi.getWebhookApi("{region}", "{groupId}", "{policyId}");
 
   FluentIterable<Webhook> webhooks = webhookApi.list();
 

--- a/src/docs/auto-scale/getting-started/samples/update_scaling_group_details.rst
+++ b/src/docs/auto-scale/getting-started/samples/update_scaling_group_details.rst
@@ -17,7 +17,7 @@
 
 .. code-block:: java
 
-  GroupApi groupApi = autoscaleApi.getGroupApiForZone("{region}");
+  GroupApi groupApi = autoscaleApi.getGroupApi("{region}");
 
   GroupConfiguration groupConfiguration = GroupConfiguration.builder()
           .maxEntities(25)

--- a/src/docs/auto-scale/getting-started/samples/update_scaling_policy.rst
+++ b/src/docs/auto-scale/getting-started/samples/update_scaling_policy.rst
@@ -16,7 +16,7 @@
 
 .. code-block:: java
 
-  PolicyApi policyApi = autoscaleApi.getPolicyApiForZoneAndGroup("{region}", "{scalingGroupId}");
+  PolicyApi policyApi = autoscaleApi.getPolicyApi("{region}", "{scalingGroupId}");
 
   CreateScalingPolicy scalingPolicy = CreateScalingPolicy.builder()
             .cooldown(3)

--- a/src/docs/auto-scale/getting-started/samples/update_scaling_webhook.rst
+++ b/src/docs/auto-scale/getting-started/samples/update_scaling_webhook.rst
@@ -16,7 +16,7 @@
 .. code-block:: java
 
   WebhookApi webhookApi =
-    autoscaleApi.getWebhookApiForZoneAndGroupAndPolicy("{region}", "{groupId}", "{policyId}");
+    autoscaleApi.getWebhookApi("{region}", "{groupId}", "{policyId}");
 
   webhookApi.update("{webhookId}", "New name", ImmutableMap.<String, Object>of());
 

--- a/src/docs/cdn/getting-started/samples/authentication.rst
+++ b/src/docs/cdn/getting-started/samples/authentication.rst
@@ -27,7 +27,10 @@
 
 .. code-block:: java
 
-  // Not currently supported by this SDK
+  // Authentication in jclouds is lazy and happens on the first call to the cloud.
+  PoppyApi poppyApi = ContextBuilder.newBuilder("rackspace-cdn-us")
+      .credentials("{username}", "{apiKey}")
+      .buildApi(PoppyApi.class);
 
 .. code-block:: javascript
 

--- a/src/docs/cdn/getting-started/samples/create_service.rst
+++ b/src/docs/cdn/getting-started/samples/create_service.rst
@@ -31,7 +31,7 @@
           Domain.builder().domain("www.example.com").build()))
       .origins(
         ImmutableList.of(
-          Origin.builder().origin("example.com")))
+          Origin.builder().origin("example.com").build()))
       .flavorId("{flavorId}")
       .build());
 

--- a/src/docs/cdn/getting-started/samples/create_service.rst
+++ b/src/docs/cdn/getting-started/samples/create_service.rst
@@ -32,6 +32,8 @@
       .origins(
         ImmutableList.of(
           Origin.builder().origin("example.com").build()))
+      .caching(new ArrayList<Caching>())
+      .restrictions(new ArrayList<Restriction>())
       .flavorId("{flavorId}")
       .build());
 

--- a/src/docs/cdn/getting-started/samples/create_service.rst
+++ b/src/docs/cdn/getting-started/samples/create_service.rst
@@ -25,7 +25,7 @@
   ServiceApi serviceApi = poppyApi.getServiceApi();
   URI serviceURI = serviceApi.create(
     CreateService.builder()
-      .name("example_site"),
+      .name("example_site")
       .domains(
         ImmutableList.of(
           Domain.builder().domain("www.example.com").build()))

--- a/src/docs/cdn/getting-started/samples/create_service.rst
+++ b/src/docs/cdn/getting-started/samples/create_service.rst
@@ -22,7 +22,18 @@
 
 .. code-block:: java
 
-  // Not currently supported by this SDK
+  ServiceApi serviceApi = poppyApi.getServiceApi();
+  URI serviceURI = serviceApi.create(
+    CreateService.builder()
+      .name("example_site"),
+      .domains(
+        ImmutableList.of(
+          Domain.builder().domain("www.example.com").build()))
+      .origins(
+        ImmutableList.of(
+          Origin.builder().origin("example.com")))
+      .flavorId("{flavorId}")
+      .build());
 
 .. code-block:: javascript
 

--- a/src/docs/cdn/getting-started/samples/create_service.rst
+++ b/src/docs/cdn/getting-started/samples/create_service.rst
@@ -22,6 +22,8 @@
 
 .. code-block:: java
 
+  // TODO: Remove the .caching(...) and .restrictions(...) calls below
+  // when this bug is fixed: https://issues.apache.org/jira/browse/JCLOUDS-877
   ServiceApi serviceApi = poppyApi.getServiceApi();
   URI serviceURI = serviceApi.create(
     CreateService.builder()

--- a/src/docs/cdn/getting-started/samples/create_service.rst
+++ b/src/docs/cdn/getting-started/samples/create_service.rst
@@ -32,8 +32,8 @@
       .origins(
         ImmutableList.of(
           Origin.builder().origin("example.com").build()))
-      .caching(new ArrayList<Caching>())
-      .restrictions(new ArrayList<Restriction>())
+      .caching(Collections.<Caching>emptyList())
+      .restrictions(Collections.<Restriction>emptyList())
       .flavorId("{flavorId}")
       .build());
 

--- a/src/docs/cdn/getting-started/samples/delete_service.rst
+++ b/src/docs/cdn/getting-started/samples/delete_service.rst
@@ -8,7 +8,7 @@
 
 .. code-block:: java
 
-  // Not currently supported by this SDK
+  serviceApi.delete("{serviceId}");
 
 .. code-block:: javascript
 

--- a/src/docs/cdn/getting-started/samples/get_flavor.rst
+++ b/src/docs/cdn/getting-started/samples/get_flavor.rst
@@ -8,7 +8,7 @@
 
 .. code-block:: java
 
-  // Not currently supported by this SDK
+  Flavor flavor = flavorApi.get("{flavorId}");
 
 .. code-block:: javascript
 

--- a/src/docs/cdn/getting-started/samples/get_service.rst
+++ b/src/docs/cdn/getting-started/samples/get_service.rst
@@ -8,7 +8,7 @@
 
 .. code-block:: java
 
-  // Not currently supported by this SDK
+  Service service = serviceApi.get("{serviceId}");
 
 .. code-block:: javascript
 

--- a/src/docs/cdn/getting-started/samples/list_flavors.rst
+++ b/src/docs/cdn/getting-started/samples/list_flavors.rst
@@ -14,7 +14,7 @@
 
 .. code-block:: java
 
-  // Not currently supported by this SDK
+  FluentIterable<Flavor> flavors = poppyApi.getFlavorApi().list();
 
 .. code-block:: javascript
 

--- a/src/docs/cdn/getting-started/samples/list_services.rst
+++ b/src/docs/cdn/getting-started/samples/list_services.rst
@@ -14,7 +14,7 @@
 
 .. code-block:: java
 
-  // Not currently supported by this SDK
+  PagedIterable<Service> services = poppyApi.getServiceApi().list();
 
 .. code-block:: javascript
 

--- a/src/docs/cdn/getting-started/samples/update_service.rst
+++ b/src/docs/cdn/getting-started/samples/update_service.rst
@@ -17,7 +17,12 @@
 
 .. code-block:: java
 
-  // Not currently supported by this SDK
+  URI serviceURI = serviceApi.update(
+    service.getId(),
+    service,
+    service.toUpdatableService()
+      .name("updated service name")
+      .build());
 
 .. code-block:: javascript
 

--- a/src/docs/cloud-block-storage/getting-started/samples/create_snapshot.rst
+++ b/src/docs/cloud-block-storage/getting-started/samples/create_snapshot.rst
@@ -13,8 +13,8 @@
 
 .. code-block:: java
 
-  VolumeApi volumeApi = cinderApi.getVolumeApiForZone("{region}");
-  SnapshotApi snapshotApi = cinderApi.getSnapshotApiForZone("{region}");
+  VolumeApi volumeApi = cinderApi.getVolumeApi("{region}");
+  SnapshotApi snapshotApi = cinderApi.getSnapshotApi("{region}");
 
   // Get the volume to snapshot
   Volume volume = volumeApi.get("{volumeId}")

--- a/src/docs/cloud-block-storage/getting-started/samples/create_volume.rst
+++ b/src/docs/cloud-block-storage/getting-started/samples/create_volume.rst
@@ -16,7 +16,7 @@
 
 .. code-block:: java
 
-  VolumeApi volumeApi = cinderApi.getVolumeApiForZone("{region}");
+  VolumeApi volumeApi = cinderApi.getVolumeApi("{region}");
 
   CreateVolumeOptions options = CreateVolumeOptions.Builder
           .name("photos")

--- a/src/docs/cloud-block-storage/getting-started/samples/delete_snapshot.rst
+++ b/src/docs/cloud-block-storage/getting-started/samples/delete_snapshot.rst
@@ -8,7 +8,7 @@
 
 .. code-block:: java
 
-  SnapshotApi snapshotApi = cinderApi.getSnapshotApiForZone("{region}");
+  SnapshotApi snapshotApi = cinderApi.getSnapshotApi("{region}");
 
   snapshotApi.delete("{snapshotId}");
 

--- a/src/docs/cloud-block-storage/getting-started/samples/delete_volume.rst
+++ b/src/docs/cloud-block-storage/getting-started/samples/delete_volume.rst
@@ -8,7 +8,7 @@
 
 .. code-block:: java
 
-  VolumeApi volumeApi = cinderApi.getVolumeApiForZone("{region}");
+  VolumeApi volumeApi = cinderApi.getVolumeApi("{region}");
 
   volumeApi.delete("{volumeId}");
 

--- a/src/docs/cloud-block-storage/getting-started/samples/list_snapshots.rst
+++ b/src/docs/cloud-block-storage/getting-started/samples/list_snapshots.rst
@@ -14,7 +14,7 @@
 
 .. code-block:: java
 
-  SnapshotApi snapshotApi = cinderApi.getSnapshotApiForZone("{region}");
+  SnapshotApi snapshotApi = cinderApi.getSnapshotApi("{region}");
 
   List<Snapshot> snapshots = snapshotApi.listInDetail().toList();
 

--- a/src/docs/cloud-block-storage/getting-started/samples/list_volumes.rst
+++ b/src/docs/cloud-block-storage/getting-started/samples/list_volumes.rst
@@ -14,7 +14,7 @@
 
 .. code-block:: java
 
-  VolumeApi volumeApi = cinderApi.getVolumeApiForZone("{region}");
+  VolumeApi volumeApi = cinderApi.getVolumeApi("{region}");
 
   List<Volume> volumes = volumeApi.listInDetail().toList();
 

--- a/src/docs/cloud-block-storage/getting-started/samples/show_snapshot.rst
+++ b/src/docs/cloud-block-storage/getting-started/samples/show_snapshot.rst
@@ -9,7 +9,7 @@
 
 .. code-block:: java
 
-  SnapshotApi snapshotApi = cinderApi.getSnapshotApiForZone("{region}");
+  SnapshotApi snapshotApi = cinderApi.getSnapshotApi("{region}");
 
   Snapshot snapshot = snapshotApi.get("{snapshotId}");
 

--- a/src/docs/cloud-block-storage/getting-started/samples/show_volume.rst
+++ b/src/docs/cloud-block-storage/getting-started/samples/show_volume.rst
@@ -9,7 +9,7 @@
 
 .. code-block:: java
 
-  VolumeApi volumeApi = cinderApi.getVolumeApiForZone("{region}");
+  VolumeApi volumeApi = cinderApi.getVolumeApi("{region}");
 
   Volume volume = volumeApi.get("{volumeId}");
 

--- a/src/docs/cloud-databases/getting-started/samples/check_root_status.rst
+++ b/src/docs/cloud-databases/getting-started/samples/check_root_status.rst
@@ -11,7 +11,7 @@
 
 .. code-block:: java
 
-  InstanceApi instanceApi = troveApi.getInstanceApiForZone("{region}");
+  InstanceApi instanceApi = troveApi.getInstanceApi("{region}");
 
   instanceApi.isRooted("{instanceId}");
 

--- a/src/docs/cloud-databases/getting-started/samples/create_db.rst
+++ b/src/docs/cloud-databases/getting-started/samples/create_db.rst
@@ -15,7 +15,7 @@
 
 .. code-block:: java
 
-  DatabaseApi databaseApi = troveApi.getDatabaseApiForZoneAndInstance("{region}", "{instanceId}");
+  DatabaseApi databaseApi = troveApi.getDatabaseApi("{region}", "{instanceId}");
 
   databaseApi.create("{databaseName}");
 

--- a/src/docs/cloud-databases/getting-started/samples/create_user.rst
+++ b/src/docs/cloud-databases/getting-started/samples/create_user.rst
@@ -17,7 +17,7 @@
 .. code-block:: java
 
   // Create a user with username and password and give them access to one database.
-  UserApi userApi = troveApi.getUserApiForZoneAndInstance("{region}", "{instanceId}");
+  UserApi userApi = troveApi.getUserApi("{region}", "{instanceId}");
 
   userApi.create("{dbUsername}", "{dbPassword}", "{dbName}");
 

--- a/src/docs/cloud-databases/getting-started/samples/enable_root_user.rst
+++ b/src/docs/cloud-databases/getting-started/samples/enable_root_user.rst
@@ -11,7 +11,7 @@
 
 .. code-block:: java
 
-  InstanceApi instanceApi = troveApi.getInstanceApiForZone("{region}");
+  InstanceApi instanceApi = troveApi.getInstanceApi("{region}");
 
   String password = instanceApi.enableRoot("{instanceId}");
 

--- a/src/docs/cloud-databases/getting-started/samples/get_flavor.rst
+++ b/src/docs/cloud-databases/getting-started/samples/get_flavor.rst
@@ -10,7 +10,7 @@
 
 .. code-block:: java
 
-  FlavorApi flavorApi = troveApi.getFlavorApiForZone("{region}");
+  FlavorApi flavorApi = troveApi.getFlavorApi("{region}");
 
   Flavor flavor = flavorApi.get("{flavorId}");
 

--- a/src/docs/cloud-databases/getting-started/samples/list_flavors.rst
+++ b/src/docs/cloud-databases/getting-started/samples/list_flavors.rst
@@ -10,7 +10,7 @@
 .. code-block:: java
 
   // List your flavors and get the first.
-  FlavorApi flavorApi = troveApi.getFlavorApiForZone("{region}");
+  FlavorApi flavorApi = troveApi.getFlavorApi("{region}");
 
   FluentIterable<Flavor> flavors = flavorApi.list();
 

--- a/src/docs/cloud-dns/getting-started/samples/create_record.rst
+++ b/src/docs/cloud-dns/getting-started/samples/create_record.rst
@@ -25,7 +25,7 @@
 
 .. code-block:: java
 
-  RecordApi recordApi = cloudDNSApi.getRecordApiForDomain({domainId});
+  RecordApi recordApi = cloudDNSApi.getRecordApi({domainId});
 
   Record createARecord = Record.builder()
           .type("A")

--- a/src/docs/cloud-dns/getting-started/samples/delete_record.rst
+++ b/src/docs/cloud-dns/getting-started/samples/delete_record.rst
@@ -9,7 +9,7 @@
 			
 .. code-block:: java
 
-  RecordApi recordApi = cloudDNSApi.getRecordApiForDomain({domainId});
+  RecordApi recordApi = cloudDNSApi.getRecordApi({domainId});
 
   awaitComplete(cloudDNSApi, recordApi.delete({recordIds}));
 

--- a/src/docs/cloud-dns/getting-started/samples/get_record.rst
+++ b/src/docs/cloud-dns/getting-started/samples/get_record.rst
@@ -17,7 +17,7 @@
 
 .. code-block:: java
 
-  RecordApi recordApi = cloudDNSApi.getRecordApiForDomain({domainId}});
+  RecordApi recordApi = cloudDNSApi.getRecordApi({domainId}});
 
   RecordDetail record = recordApi.get({recordId}});
 

--- a/src/docs/cloud-dns/getting-started/samples/modify_record.rst
+++ b/src/docs/cloud-dns/getting-started/samples/modify_record.rst
@@ -23,7 +23,7 @@
 
 .. code-block:: java
 
-  RecordApi recordApi = cloudDNSApi.getRecordApiForDomain({domainId}});
+  RecordApi recordApi = cloudDNSApi.getRecordApi({domainId}});
 
   Record updateRecord = Record.builder()
           .data("192.168.1.2")

--- a/src/docs/cloud-load-balancers/getting-started/samples/blacklist_ips.rst
+++ b/src/docs/cloud-load-balancers/getting-started/samples/blacklist_ips.rst
@@ -22,7 +22,7 @@
 .. code-block:: java
 
   AccessRuleApi accessRuleApi =
-      clbApi.getAccessRuleApiForZoneAndLoadBalancer("{region}", "{loadBalancerId}");
+      clbApi.getAccessRuleApi("{region}", "{loadBalancerId}");
 
   AccessRule rule1 = AccessRule.deny("206.160.165.0/24");
   AccessRule rule2 = AccessRule.allow("206.160.165.0/2");

--- a/src/docs/cloud-load-balancers/getting-started/samples/create_health_monitor.rst
+++ b/src/docs/cloud-load-balancers/getting-started/samples/create_health_monitor.rst
@@ -29,7 +29,7 @@
 .. code-block:: java
 
   HealthMonitorApi healthMonitorApi =
-      clbApi.getHealthMonitorApiForZoneAndLoadBalancer("{region}", "{loadBalancerId}");
+      clbApi.getHealthMonitorApi("{region}", "{loadBalancerId}");
 
   HealthMonitor healthMonitor = HealthMonitor.builder()
       .type(HealthMonitor.Type.CONNECT)

--- a/src/docs/cloud-load-balancers/getting-started/samples/create_lb.rst
+++ b/src/docs/cloud-load-balancers/getting-started/samples/create_lb.rst
@@ -35,7 +35,7 @@
 
 .. code-block:: java
 
-  LoadBalancerApi lbApi = clbApi.getLoadBalancerApiForZone("{region}");
+  LoadBalancerApi lbApi = clbApi.getLoadBalancerApi("{region}");
 
   CreateLoadBalancer createLB = CreateLoadBalancer.builder()
       .name("My Load Balancer")

--- a/src/docs/cloud-load-balancers/getting-started/samples/create_nodes.rst
+++ b/src/docs/cloud-load-balancers/getting-started/samples/create_nodes.rst
@@ -37,7 +37,7 @@
 
 .. code-block:: java
 
-  NodeApi nodeApi = clbApi.getNodeApiForZoneAndLoadBalancer("{region}", "{loadBalancerId}");
+  NodeApi nodeApi = clbApi.getNodeApi("{region}", "{loadBalancerId}");
 
   AddNode node1 = AddNode.builder()
       .address(server1.getAccessIPv4())

--- a/src/docs/cloud-load-balancers/getting-started/samples/enable_content_caching.rst
+++ b/src/docs/cloud-load-balancers/getting-started/samples/enable_content_caching.rst
@@ -22,7 +22,7 @@
 .. code-block:: java
 
   ContentCachingApi contentCachingApi =
-      clbApi.getContentCachingApiForZoneAndLoadBalancer("{region}", "{loadBalancerId}");
+      clbApi.getContentCachingApi("{region}", "{loadBalancerId}");
 
   contentCachingApi.enable();
 

--- a/src/docs/cloud-load-balancers/getting-started/samples/get_health_monitor.rst
+++ b/src/docs/cloud-load-balancers/getting-started/samples/get_health_monitor.rst
@@ -13,7 +13,7 @@
 .. code-block:: java
 
   HealthMonitorApi healthMonitorApi =
-      clbApi.getHealthMonitorApiForZoneAndLoadBalancer("{region}", "{loadBalancerId}");
+      clbApi.getHealthMonitorApi("{region}", "{loadBalancerId}");
 
   HealthMonitor healthMonitor = healthMonitorApi.get();
 

--- a/src/docs/cloud-load-balancers/getting-started/samples/query_lb_progress.rst
+++ b/src/docs/cloud-load-balancers/getting-started/samples/query_lb_progress.rst
@@ -35,7 +35,7 @@
 
 .. code-block:: java
 
-  LoadBalancerApi lbApi = clbApi.getLoadBalancerApiForZone("{region}");
+  LoadBalancerApi lbApi = clbApi.getLoadBalancerApi("{region}");
 
   if (!LoadBalancerPredicates.awaitAvailable(lbApi).apply(loadBalancer)) {
       throw new TimeoutException("Timeout on creating load balancer: " + loadBalancer);

--- a/src/docs/cloud-load-balancers/getting-started/samples/select_servers.rst
+++ b/src/docs/cloud-load-balancers/getting-started/samples/select_servers.rst
@@ -25,7 +25,7 @@
   NovaApi novaApi = ContextBuilder.newBuilder("rackspace-cloudservers-us")
           .credentials("{username}, "{apiKey}")
           .buildApi(NovaApi.class);
-  ServerApi serverApi = novaApi.getServerApiForZone("{region}");
+  ServerApi serverApi = novaApi.getServerApi("{region}");
 
   Server server1 = serverApi.get("{serverId}");
   Server server2 = serverApi.get("{serverId}");

--- a/src/docs/cloud-load-balancers/getting-started/samples/set_custom_error_page.rst
+++ b/src/docs/cloud-load-balancers/getting-started/samples/set_custom_error_page.rst
@@ -15,7 +15,7 @@
 
 .. code-block:: java
 
-  ErrorPageApi errorPageApi = clbApi.getErrorPageApiForZoneAndLoadBalancer("{region}", "{loadBalancerId}");
+  ErrorPageApi errorPageApi = clbApi.getErrorPageApi("{region}", "{loadBalancerId}");
 
   String content = "<html><body>Something went wrong...</body></html>";
   errorPageApi.create(content);

--- a/src/docs/cloud-load-balancers/getting-started/samples/set_throttling.rst
+++ b/src/docs/cloud-load-balancers/getting-started/samples/set_throttling.rst
@@ -31,7 +31,7 @@
 .. code-block:: java
 
   ConnectionApi connectionApi =
-      clbApi.getConnectionApiForZoneAndLoadBalancer("{region}", "{loadBalancerId}");
+      clbApi.getConnectionApi("{region}", "{loadBalancerId}");
 
   ConnectionThrottle throttle = ConnectionThrottle.builder()
       .maxConnectionRate(10000)

--- a/src/docs/cloud-queues/getting-started/samples/claim_message.rst
+++ b/src/docs/cloud-queues/getting-started/samples/claim_message.rst
@@ -18,7 +18,7 @@
 .. code-block:: java
 
   ClaimApi claimApi =
-      marconiApi.getClaimApiForZoneAndClientAndQueue("{region}", "{clientId}", "{queueName}");
+      marconiApi.getClaimApi("{region}", "{clientId}", "{queueName}");
 
   List<Message> messages = claimApi.claim(900, 120, 4);
 

--- a/src/docs/cloud-queues/getting-started/samples/create_queue.rst
+++ b/src/docs/cloud-queues/getting-started/samples/create_queue.rst
@@ -10,7 +10,7 @@
 
 .. code-block:: java
 
-  QueueApi queueApi = marconiApi.getQueueApiForZoneAndClient("{region}", "{clientId}");
+  QueueApi queueApi = marconiApi.getQueueApi("{region}", "{clientId}");
 
   queueApi.create("{queueName}");
 

--- a/src/docs/cloud-queues/getting-started/samples/delete_message.rst
+++ b/src/docs/cloud-queues/getting-started/samples/delete_message.rst
@@ -11,7 +11,7 @@
 .. code-block:: java
 
   MessageApi messageApi =
-      marconiApi.getMessageApiForZoneAndClientAndQueue("{region}", "{clientId}", "{queueName}");
+      marconiApi.getMessageApi("{region}", "{clientId}", "{queueName}");
 
   List<String> messageIds = ImmutableList.of("{messageId}");
 

--- a/src/docs/cloud-queues/getting-started/samples/delete_queue.rst
+++ b/src/docs/cloud-queues/getting-started/samples/delete_queue.rst
@@ -9,7 +9,7 @@
 
 .. code-block:: java
 
-  QueueApi queueApi = marconiApi.getQueueApiForZoneAndClient("{region}", "{clientId}");
+  QueueApi queueApi = marconiApi.getQueueApi("{region}", "{clientId}");
 
   queueApi.delete("{queueName}");
 

--- a/src/docs/cloud-queues/getting-started/samples/list_queues.rst
+++ b/src/docs/cloud-queues/getting-started/samples/list_queues.rst
@@ -9,7 +9,7 @@
 
 .. code-block:: java
 
-  QueueApi queueApi = marconiApi.getQueueApiForZoneAndClient("{region}", "{clientId}");
+  QueueApi queueApi = marconiApi.getQueueApi("{region}", "{clientId}");
 
   List<Queue> queues = queueApi.list(true).concat().toList();
 

--- a/src/docs/cloud-queues/getting-started/samples/post_message.rst
+++ b/src/docs/cloud-queues/getting-started/samples/post_message.rst
@@ -15,7 +15,7 @@
 .. code-block:: java
 
     MessageApi messageApi =
-        marconiApi.getMessageApiForZoneAndClientAndQueue("{region}", "{clientId}", "{queueName}");
+        marconiApi.getMessageApi("{region}", "{clientId}", "{queueName}");
 
     CreateMessage createMessage = CreateMessage.builder()
             .ttl(900)

--- a/src/docs/cloud-queues/getting-started/samples/release_message.rst
+++ b/src/docs/cloud-queues/getting-started/samples/release_message.rst
@@ -18,7 +18,7 @@
 .. code-block:: java
 
   ClaimApi claimApi =
-      marconiApi.getClaimApiForZoneAndClientAndQueue("{region}", "{clientId}", "{queueName}");
+      marconiApi.getClaimApi("{region}", "{clientId}", "{queueName}");
 
   claimApi.release("{claimId}");
 

--- a/src/docs/cloud-servers/getting-started/samples/create_new_keypair.rst
+++ b/src/docs/cloud-servers/getting-started/samples/create_new_keypair.rst
@@ -10,7 +10,7 @@
 
 .. code-block:: java
 
-  KeyPairApi keyPairApi = novaApi.getKeyPairExtensionForZone("{region}").get();
+  KeyPairApi keyPairApi = novaApi.getKeyPairApi("{region}").get();
 
   KeyPair keyPair = keyPairApi.create("my-keypair");
 

--- a/src/docs/cloud-servers/getting-started/samples/create_server.rst
+++ b/src/docs/cloud-servers/getting-started/samples/create_server.rst
@@ -12,7 +12,7 @@
 
 .. code-block:: java
 
-  ServerApi serverApi = novaApi.getServerApiForZone("{region}");
+  ServerApi serverApi = novaApi.getServerApi("{region}");
 
   ServerCreated serverCreated = serverApi.create("My new server", "{imageId}", "{flavorId}");
 

--- a/src/docs/cloud-servers/getting-started/samples/create_server_with_keypair.rst
+++ b/src/docs/cloud-servers/getting-started/samples/create_server_with_keypair.rst
@@ -13,7 +13,7 @@
 
 .. code-block:: java
 
-  ServerApi serverApi = novaApi.getServerApiForZone("{region}");
+  ServerApi serverApi = novaApi.getServerApi("{region}");
 
   CreateServerOptions options = CreateServerOptions.Builder.keyPairName("my-keypair");
   ServerCreated serverCreated = serverApi.create("My server", "{imageId}", "{flavorId}", options);

--- a/src/docs/cloud-servers/getting-started/samples/delete_server.rst
+++ b/src/docs/cloud-servers/getting-started/samples/delete_server.rst
@@ -8,7 +8,7 @@
 
 .. code-block:: java
 
-  ServerApi serverApi = novaApi.getServerApiForZone("{region}");
+  ServerApi serverApi = novaApi.getServerApi("{region}");
 
   serverApi.delete("{serverId}");
 

--- a/src/docs/cloud-servers/getting-started/samples/get_flavor.rst
+++ b/src/docs/cloud-servers/getting-started/samples/get_flavor.rst
@@ -8,7 +8,7 @@
 
 .. code-block:: java
 
-  FlavorApi flavorApi = novaApi.getFlavorApiForZone("{region}");
+  FlavorApi flavorApi = novaApi.getFlavorApi("{region}");
 
   Flavor flavor = flavorApi.get("{flavorId}");
 

--- a/src/docs/cloud-servers/getting-started/samples/get_image.rst
+++ b/src/docs/cloud-servers/getting-started/samples/get_image.rst
@@ -8,7 +8,7 @@
 
 .. code-block:: java
 
-  ImageApi imageApi = novaApi.getImageApiForZone("{region}");
+  ImageApi imageApi = novaApi.getImageApi("{region}");
 
   Image image = imageApi.get("{imageId}");
 

--- a/src/docs/cloud-servers/getting-started/samples/list_flavors.rst
+++ b/src/docs/cloud-servers/getting-started/samples/list_flavors.rst
@@ -12,7 +12,7 @@
 
 .. code-block:: java
 
-  FlavorApi flavorApi = novaApi.getFlavorApiForZone("{region}");
+  FlavorApi flavorApi = novaApi.getFlavorApi("{region}");
 
   ImmutableList<? extends Flavor> flavors = flavorApi.listInDetail().concat().toList();
 

--- a/src/docs/cloud-servers/getting-started/samples/list_images.rst
+++ b/src/docs/cloud-servers/getting-started/samples/list_images.rst
@@ -12,7 +12,7 @@
 
 .. code-block:: java
 
-  ImageApi imageApi = novaApi.getImageApiForZone("{region}");
+  ImageApi imageApi = novaApi.getImageApi("{region}");
 
   ImmutableList<? extends Image> images = imageApi.listInDetail().concat().toList();
 

--- a/src/docs/cloud-servers/getting-started/samples/query_server_build.rst
+++ b/src/docs/cloud-servers/getting-started/samples/query_server_build.rst
@@ -11,7 +11,7 @@
 
 .. code-block:: java
 
-  ServerApi serverApi = novaApi.getServerApiForZone("{region}");
+  ServerApi serverApi = novaApi.getServerApi("{region}");
 
   ServerPredicates.awaitActive(serverApi).apply("{serverId}")
 

--- a/src/docs/cloud-servers/getting-started/samples/upload_existing_keypair.rst
+++ b/src/docs/cloud-servers/getting-started/samples/upload_existing_keypair.rst
@@ -12,7 +12,7 @@
 
 .. code-block:: java
 
-  KeyPairApi keyPairApi = novaApi.getKeyPairExtensionForZone("{region}").get();
+  KeyPairApi keyPairApi = novaApi.getKeyPairApi("{region}").get();
 
   File keyPairFile = new File("{/home/my-user/.ssh/id_rsa.pub}");
   String publicKey = Files.toString(keyPairFile, UTF_8); // Using com.google.common.io.Files

--- a/src/site_source/sdks/java/pom.xml
+++ b/src/site_source/sdks/java/pom.xml
@@ -55,6 +55,11 @@
       <artifactId>rackspace-clouddns-us</artifactId>
       <version>${jclouds.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>rackspace-cdn-us</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
     <!-- Rackspace UK dependencies -->
     <dependency>
       <groupId>org.apache.jclouds.provider</groupId>
@@ -95,6 +100,11 @@
       <groupId>org.apache.jclouds.provider</groupId>
       <artifactId>rackspace-clouddns-uk</artifactId>
       <version>${jclouds.version}</version>
+   </dependency>
+   <dependency>
+     <groupId>org.apache.jclouds.labs</groupId>
+     <artifactId>rackspace-cdn-uk</artifactId>
+     <version>${jclouds.version}</version>
    </dependency>
   </dependencies>
 </project>

--- a/src/site_source/sdks/java/pom.xml
+++ b/src/site_source/sdks/java/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <properties>
-    <jclouds.version>1.7.3</jclouds.version>
+    <jclouds.version>1.9.0</jclouds.version>
   </properties>
   <groupId>com.mycompany.app</groupId>
   <artifactId>my-app</artifactId>


### PR DESCRIPTION
Please **DO NOT MERGE** until jclouds 1.9.0 is released. To check this, [search for jclouds 1.9.0 on Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.jclouds%22%20AND%20a%3A%22jclouds%22%20AND%20v%3A%221.9.0%22) and make sure the search results are not empty.

This PR supersedes #1057.

Note that jclouds does not (yet?) support the [Purge Assets API](http://docs.rackspace.com/cdn/api/v1.0/cdn-devguide/content/DELETE_deleteCachedAsset__services__service_id__assets_serviceAssetsOperations.html). Consequently this PR does not include Java samples in: 
* `purge_specific_service_asset.rst`, and
* `purge_all_service_assets.rst`

This missing functionality will be [added](https://github.com/jclouds/jclouds-labs-openstack/pull/182) in a later release. When that happens, we will send in a new PR to add Java samples to the two `.rst` files listed above.

**UPDATE:** This PR now also includes changes to non-CDN jclouds code - snippets used in each of the services' quick start guides as well as full examples. This is because jclouds 1.9.0 is required to use CDN and that version introduced some backwards-incompatible changes in other services (for details see comments starting with https://github.com/rackerlabs/developer.rackspace.com/pull/1094#issuecomment-87830845).