### PR TITLE
add cloud load balancers link for go

### DIFF
--- a/src/site_source/sdks/golang/index.html
+++ b/src/site_source/sdks/golang/index.html
@@ -7,9 +7,10 @@ title: Go SDK
   <p>Rackspace's official SDK for Go is <a href="http://gophercloud.io">Gophercloud</a>, an Apache-licensed open-source community project for using multiple cloud providers from a standardized API.</p>
   <p>Currently, Gophercloud has support for multiple Rackspace services:</p>
    <ul>
+     <li><a href="/docs/cloud-block-storage/getting-started/?lang=go">Cloud Block Storage</a></li>
      <li><a href="/docs/cloud-files/getting-started/?lang=go">Cloud Files</a></li>
+     <li><a href="/docs/cloud-load-balancers/getting-started/?lang=go">Cloud Load Balancers</a></li>
      <li><a href="/docs/cloud-servers/getting-started/?lang=go">Cloud Servers</a></li>
-    <li><a href="/docs/cloud-block-storage/getting-started/?lang=go">Cloud Block Storage</a></li>
    </ul>
   <p>Support for additional services is on-going.</p>
   <hr />


### PR DESCRIPTION
The Cloud Load Balancer getting started examples have been there for a while. This PR adds a link on the Go SDK page to the getting started examples.