### PR TITLE
Go code sample fixes

### DIFF
--- a/src/docs/cloud-identity/getting-started/samples/delete_user.rst
+++ b/src/docs/cloud-identity/getting-started/samples/delete_user.rst
@@ -2,7 +2,7 @@
 
 .. code-block:: go
 
-  err := users.Delete(client, "{userId}").ExtractErr()
+  _, err := users.Delete(client, "{userId}").Extract()
 
 .. code-block:: java
 

--- a/src/docs/cloud-identity/getting-started/samples/setup.rst
+++ b/src/docs/cloud-identity/getting-started/samples/setup.rst
@@ -17,7 +17,7 @@
     APIKey: "{apiKey}",
   })
 
-  client, err := rackspace.NewIdentityV2(provider)
+  client := rackspace.NewIdentityV2(provider)
 
 .. code-block:: java
 


### PR DESCRIPTION
This PR fixes the syntax of a couple of Gophercloud samples for Identity. PR to `master` because these should be fixed immediately.