### PR TITLE
Removing the sticky-top navbar for mobile

### DIFF
--- a/src/site_source/_assets/css/components/body.less
+++ b/src/site_source/_assets/css/components/body.less
@@ -1,5 +1,10 @@
 body {
   margin-top: 74px;
+
+  @media (max-width: @grid-float-breakpoint) {
+    margin-top: 0;
+  }
+
 }
 
 .body-container {

--- a/src/site_source/_assets/css/components/header.less
+++ b/src/site_source/_assets/css/components/header.less
@@ -5,6 +5,11 @@
   border: none;
   border-bottom: 2px solid @rackspace-white;
 
+  &.navbar {
+    @media (max-width: @grid-float-breakpoint) {
+      position: relative;
+    }
+  }
   .navbar-toggle {
     margin-top: 20px;
   }
@@ -78,6 +83,7 @@
     }
   }
 }
+
 
 
 


### PR DESCRIPTION
This makes the gray top bar not `position: fixed` on devices less than 768 pixels wide.