### PR TITLE
PyCon 2015 blog post

### DIFF
--- a/src/site_source/_posts/2015-04-07-rackspace-at-pycon.md
+++ b/src/site_source/_posts/2015-04-07-rackspace-at-pycon.md
@@ -11,7 +11,7 @@ categories:
 [PyCon 2015](https://us.pycon.org/2015/), the annual Python conference,
 kicks off this week in Montréal and Rackspace will be there in full force.
 Python use at Rackspace is huge, from our work on OpenStack and many other
-related products, whether internal and external, so it made perfect sense
+related products, whether internal and external, so it makes perfect sense
 for us to support the conference at the Diamond level.
 
 We'll have 13 sessions given by 10 speakers throughout the conference's tutorial and talk schedule,

--- a/src/site_source/_posts/2015-04-07-rackspace-at-pycon.md
+++ b/src/site_source/_posts/2015-04-07-rackspace-at-pycon.md
@@ -1,0 +1,178 @@
+---
+layout: post
+title: "Rackspace at PyCon 2015"
+date: 2015-04-07 10:00
+comments: false
+author: Brian Curtin
+categories:
+    - PyCon
+---
+
+[PyCon 2015](https://us.pycon.org/2015/), the annual Python conference,
+kicks off this week in Montréal and Rackspace will be there in full force.
+Python use at Rackspace is huge, from our work on OpenStack and many other
+related products, whether internal and external, so it made perfect sense
+for us to support the conference at the Diamond level.
+
+We'll have 14 sessions given by 11 speakers throughout the conference's tutorial and talk schedule,
+and our very own Van Lindberg, chairman of the Python Software Foundation,
+will deliver the chairman's address in a keynote slot on Sunday morning.
+
+Be sure to stop by the Rackspace booth in the expo hall, and check out
+the tutorials and talks that we're giving throughout the conference!
+
+### [Shiny, Let's Be Bad Guys: Exploiting and Mitigating the Top 10 Web App Vulnerabilities](https://us.pycon.org/2015/schedule/presentation/304/)
+
+* *David Stanek and Mike Pirnat*
+* *Wednesday @ 9 AM (Tutorial, Room 513D, $150)*
+
+The Internet is a dangerous place, filled with evildoers out to attack your
+code for fun or profit, so it's not enough to just ship your awesome new web
+app--you have to take the security of your application, your users,
+and your data seriously. You'll get into the mindset of the bad guys as we
+discuss, exploit, and mitigate the most common web app security flaws in a
+controlled environment.
+
+### [Flask Workshop](https://us.pycon.org/2015/schedule/presentation/308/)
+
+* *Miguel Grinberg*
+* *Wednesday @ 9 AM (Tutorial, Room 512DH, $150)*
+
+Flask is a web framework for Python based on Werkzeug, Jinja 2 and good
+intentions. It is considered a micro-framework, but don't get the "micro"
+part fool you; Flask can do everything others can do, many times in
+a simpler, leaner way. In this tutorial session we will build a web
+application together. Bring your laptop and your questions!
+
+### [A hands-on introduction to Python for beginning programmers](https://us.pycon.org/2015/schedule/presentation/296/)
+
+* *Dana Bauer*
+* *Wednesday @ 9 AM (Tutorial, Room 513A, $150)*
+
+Beginning programmers: welcome to PyCon! Jumpstart your Python and
+programming careers with this 3-hour interactive tutorial. By the end,
+you'll have hands-on exposure to many core programming concepts, be able
+to write useful Python programs, and have a roadmap for continuing to
+learn and practice programming in Python. This class assumes no prior
+programming experience.
+
+### [IPython & Jupyter in depth: high productivity interactive and parallel python](https://us.pycon.org/2015/schedule/presentation/316/)
+
+* *Kyle Kelley and Thomas Kluyver*
+* *Wednesday @ 1:20 PM (Tutorial, Room 510B, $150)*
+
+IPython and Jupyter provide tools for interactive and parallel computing
+that are widely used in scientific computing, but can benefit any Python
+developer. We will show how to use IPython in different ways, as:
+an interactive shell, a graphical console, a network-aware VM in GUIs,
+a web-based notebook with code, graphics and rich HTML, and a high-level
+framework for parallel computing.
+
+### [What to do when you need crypto](https://us.pycon.org/2015/schedule/presentation/305/)
+
+* *Jarret Raim and Paul Kehrer*
+* *Wednesday @ 1:20 PM (Tutorial, Room 512FB, $150)*
+
+The cryptographic world doesn't lend itself to the typical developer flow
+of learning while doing. Add that to the massive amount of bad or outdated
+information on the web and many developers are lost or worse, build
+insecure systems. This tutorial will introduce developers to modern
+cryptography with an eye towards practical scenarios around password
+management, encryption and key management.
+
+### [Introduction to game programming with Kivy](https://us.pycon.org/2015/schedule/presentation/314/)
+
+* *Richard Jones*
+* *Thursday @ 1:20 PM (Tutorial, Room 510B, $150)*
+
+This tutorial will walk the attendees through development of a simple game
+using Kivy with time left over for some experimentation and exploration
+of different types of games.
+
+### [Hack on CloudPipe, open source distributed job runner](https://us.pycon.org/2015/schedule/presentation/472/)
+
+* *Kyle Kelley*
+* *Thursday @ 1:30 PM (Tutorial, Room 513E, FREE!)*
+
+Come learn how cloudpipe works, how to use it, and how to hack on it as
+a contributor.
+
+### [Distributed Systems 101](https://us.pycon.org/2015/schedule/presentation/386/)
+
+* *lvh*
+* *Friday @ 1:40 PM (Talk, Room 517C)*
+
+A very brief introduction to the theory and practice of distributed systems.
+
+### [The Ethical Consequences Of Our Collective Activities](https://us.pycon.org/2015/schedule/presentation/370/)
+
+* *Glyph*
+* *Saturday @ 1:55 PM (Talk, Room 710B)*
+
+As more of the world is controlled by software, software developers have
+an increasing obligation to serve that world well. Yet, we don't yet have
+a sense of what makes a good ethical standard. The fast pace, success,
+and youth (in both historical and demographic terms) of our industry have
+given us the sense that such a standard might not be required. This talk
+will correct that misconception.
+
+### [Cutting Off the Internet: Testing Applications that Use Requests](https://us.pycon.org/2015/schedule/presentation/344/)
+
+* *Ian Cordasco*
+* *Saturday @ 1:55 (Talk, Room 511)*
+
+A brief and opinionated view of testing applications and libraries that use
+requests by a core-developer of requests. You will receive an overview of
+testing with responses, vcr, httpretty, mock, and betamax.
+
+### [Schemas for the Real World](https://us.pycon.org/2015/schedule/presentation/426/)
+
+* *Carina C. Zona*
+* *Saturday @ 3:15 PM (Talk, Room 710B)*
+
+Development challenges us to code for users’ personal world. Users give
+push-back to ill-fitted assumptions about their own name, gender,
+sexual orientation, important relationships, & other attributes that are
+individually meaningful. We'll explore how to develop software that brings
+real world into focus & that allows individuals to authentically reflect
+their personhood & physical world.
+
+### [A Winning Strategy with The Weakest Link: how to use weak references to make your code more robust](https://us.pycon.org/2015/schedule/presentation/468/)
+
+* *Jim Baker*
+* *Saturday @ 5:10 PM (Talk, Room 710A)*
+
+Working with weak references should not just be for Python wizards. Whether
+you have a cache, memoizing a function, tracking objects, or various other
+bookkeeping needs, you definitely do not want code leaking memory or
+resources. In this talk, we will look at illuminating examples drawn from
+a variety of sources on how to use weak references to prevent such bugs.
+
+### Keynote
+
+* *Van Lindberg*
+* *Sunday @ 9:00 AM (Keynote, Main Room 517AB)*
+
+### [Where in your RAM is "python san_diego.py"?](https://us.pycon.org/2015/schedule/presentation/415/)
+
+* *Ying Li*
+* *Sunday @ 1:10 PM (Talk, Room 517C)*
+
+Gumshoes, the rogue program `san_diego.py` is threatening to cause havok!
+What is it doing to hide itself? What kind of things is it doing? Who might
+it be communicating with? RAM is a big place - how can we even find it,
+much less any of this information? Stay tuned and find out!
+
+### [Getting to Jython 2.7 and beyond](https://us.pycon.org/2015/schedule/presentation/351/)
+
+* *Jim Baker*
+* *Sunday @ 2:30 PM (Talk, Room 710B)*
+
+So how did we get to Jython 2.7 anyway? And what are our future plans?
+In this talk, you will get a taste of how Jython works, some new
+functionality, and especially how Jython leverages both Python and Java
+to provide a very compatible solution.
+
+---
+
+If you can't make any of these talk sessions, they'll be recorded and made available online shortly after the conference concludes. We'll have a second post to share them once they're all online!

--- a/src/site_source/_posts/2015-04-07-rackspace-at-pycon.md
+++ b/src/site_source/_posts/2015-04-07-rackspace-at-pycon.md
@@ -21,6 +21,8 @@ will deliver the chairman's address in a keynote slot on Sunday morning.
 Be sure to stop by the Rackspace booth in the expo hall, and check out
 the tutorials and talks that we're giving throughout the conference!
 
+<!-- more -->
+
 ### [Shiny, Let's Be Bad Guys: Exploiting and Mitigating the Top 10 Web App Vulnerabilities](https://us.pycon.org/2015/schedule/presentation/304/)
 
 * *David Stanek and Mike Pirnat*

--- a/src/site_source/_posts/2015-04-07-rackspace-at-pycon.md
+++ b/src/site_source/_posts/2015-04-07-rackspace-at-pycon.md
@@ -14,7 +14,7 @@ Python use at Rackspace is huge, from our work on OpenStack and many other
 related products, whether internal and external, so it made perfect sense
 for us to support the conference at the Diamond level.
 
-We'll have 14 sessions given by 11 speakers throughout the conference's tutorial and talk schedule,
+We'll have 13 sessions given by 10 speakers throughout the conference's tutorial and talk schedule,
 and our very own Van Lindberg, chairman of the Python Software Foundation,
 will deliver the chairman's address in a keynote slot on Sunday morning.
 
@@ -124,18 +124,6 @@ will correct that misconception.
 A brief and opinionated view of testing applications and libraries that use
 requests by a core-developer of requests. You will receive an overview of
 testing with responses, vcr, httpretty, mock, and betamax.
-
-### [Schemas for the Real World](https://us.pycon.org/2015/schedule/presentation/426/)
-
-* *Carina C. Zona*
-* *Saturday @ 3:15 PM (Talk, Room 710B)*
-
-Development challenges us to code for users’ personal world. Users give
-push-back to ill-fitted assumptions about their own name, gender,
-sexual orientation, important relationships, & other attributes that are
-individually meaningful. We'll explore how to develop software that brings
-real world into focus & that allows individuals to authentically reflect
-their personhood & physical world.
 
 ### [A Winning Strategy with The Weakest Link: how to use weak references to make your code more robust](https://us.pycon.org/2015/schedule/presentation/468/)
 


### PR DESCRIPTION
@briancurtin's blog post from #1120, retargeted from `dev` to :shipit: to production.