### PR TITLE
Fix shell examples in Quickstart for Cloud Servers

### DIFF
--- a/src/docs/cloud-servers/getting-started/samples/create_new_keypair.rst
+++ b/src/docs/cloud-servers/getting-started/samples/create_new_keypair.rst
@@ -55,4 +55,5 @@
 
   curl -X POST $ENDPOINT/os-keypairs -d \
     '{"keypair":{"name":"{keyPairName}"} }' \
+    -H "Content-Type: application/json" \
     -H "X-Auth-Token: $TOKEN" | python -m json.tool

--- a/src/docs/cloud-servers/getting-started/samples/create_server.rst
+++ b/src/docs/cloud-servers/getting-started/samples/create_server.rst
@@ -63,6 +63,8 @@
           "imageRef" : $IMAGE_ID,
           "flavorRef" : $FLAVOR_ID
         }
-      }' -H "X-Auth-Token: $TOKEN" | python -m json.tool
+      }' \
+      -H "Content-Type: application/json" \
+      -H "X-Auth-Token: $TOKEN" | python -m json.tool
 
   export SERVER_ID="{serverId}"

--- a/src/docs/cloud-servers/getting-started/samples/create_server.rst
+++ b/src/docs/cloud-servers/getting-started/samples/create_server.rst
@@ -60,8 +60,8 @@
     '{
       "server" : {
           "name" : "My new server",
-          "imageRef" : $IMAGE_ID,
-          "flavorRef" : $FLAVOR_ID
+          "imageRef": "'"$IMAGE_ID"'",
+          "flavorRef": '"$FLAVOR_ID"',
         }
       }' \
       -H "Content-Type: application/json" \

--- a/src/docs/cloud-servers/getting-started/samples/create_server_with_keypair.rst
+++ b/src/docs/cloud-servers/getting-started/samples/create_server_with_keypair.rst
@@ -69,4 +69,6 @@
         "flavorRef" : ${FLAVOR_ID},
         "key_name" : "my-keypair"
       }
-    }' -H "X-Auth-Token: $TOKEN" | python -m json.tool
+    }' \
+    -H "Content-Type: application/json" \
+    -H "X-Auth-Token: $TOKEN" | python -m json.tool

--- a/src/docs/cloud-servers/getting-started/samples/create_server_with_keypair.rst
+++ b/src/docs/cloud-servers/getting-started/samples/create_server_with_keypair.rst
@@ -61,7 +61,7 @@
 
 .. code-block:: sh
 
-  curl -X POST $ENDPOINT -d \
+  curl -X POST $ENDPOINT/servers -d \
     '{
       "server" : {
         "name" : "My server",

--- a/src/docs/cloud-servers/getting-started/samples/create_server_with_keypair.rst
+++ b/src/docs/cloud-servers/getting-started/samples/create_server_with_keypair.rst
@@ -65,8 +65,8 @@
     '{
       "server" : {
         "name" : "My server",
-        "imageRef" : ${IMAGE_ID},
-        "flavorRef" : ${FLAVOR_ID},
+        "imageRef": "'"$IMAGE_ID"'",
+        "flavorRef": '"$FLAVOR_ID"',
         "key_name" : "my-keypair"
       }
     }' \

--- a/src/docs/cloud-servers/getting-started/samples/delete_server.rst
+++ b/src/docs/cloud-servers/getting-started/samples/delete_server.rst
@@ -32,4 +32,4 @@
 
 .. code-block:: sh
 
-  curl -X DELETE $ENDPOINT/$SERVER_ID -H "X-Auth-Token: $TOKEN"
+  curl -X DELETE $ENDPOINT/servers/$SERVER_ID -H "X-Auth-Token: $TOKEN"

--- a/src/docs/cloud-servers/getting-started/samples/query_server_build.rst
+++ b/src/docs/cloud-servers/getting-started/samples/query_server_build.rst
@@ -40,5 +40,5 @@
 .. code-block:: sh
 
   # from resulting json below see "status"
-  curl -X GET $ENDPOINT/{serverId} \
+  curl -X GET $ENDPOINT/servers/$SERVER_ID \
     -H "X-Auth-Token: $TOKEN" | python -m json.tool

--- a/src/docs/cloud-servers/getting-started/samples/upload_existing_keypair.rst
+++ b/src/docs/cloud-servers/getting-started/samples/upload_existing_keypair.rst
@@ -73,4 +73,5 @@
         "public_key":"ssh-rsa AAAAB3Nz ..."
       }
     }' \
+    -H "Content-Type: application/json" \
     -H "X-Auth-Token: $TOKEN" | python -m json.tool


### PR DESCRIPTION
I recently walked through the Quickstart for Cloud Servers and found that a few of the shell examples fail when copy/pasted without modification.

* Set the Content-Type header when posting json
The api was returning "400: Unsupported Content-Type".

* Fix concatenation of environment variables in create server json
The IMAGE_ID and FLAVOR_ID environment variables were not being expanded.

* Fix url for server resource
It was missing the /servers suffix which caused the api to return 404 errors.